### PR TITLE
"Play programme" added into PVRInfo dialog + catchup mark in EPG + "Now playing" video as background

### DIFF
--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -3883,3 +3883,7 @@ msgstr ""
 msgctxt "#320237"
 msgid "Enable air date"
 msgstr ""
+
+msgctxt "#320238"
+msgid "Show Background \"Now Playing\" Video"
+msgstr ""

--- a/xml/DialogPVRInfo.xml
+++ b/xml/DialogPVRInfo.xml
@@ -242,6 +242,13 @@
                     <include>DialogButtonOther</include>
                     <visible>Window.IsActive(PVRRecordingInfo)</visible> 
                 </control>
+				<control type="button" id="10">
+                    <!--play programme-->
+                    <width>289</width>
+                    <label>19190</label>
+                    <include>DialogButtonOther</include>
+                    <visible>Window.IsActive(PVRGuideInfo)</visible> 
+                </control>
 				<control type="button" id="4">
 					<width>289</width>
 					<description>Find similar</description>

--- a/xml/Includes.xml
+++ b/xml/Includes.xml
@@ -98,11 +98,11 @@
 
     <expression name="IsBingieViewsVisible">Window.IsVisible(Home) | Window.IsVisible(1109) | Window.IsVisible(1119) | Window.IsVisible(1110) | Window.IsVisible(1111) | Window.IsVisible(1112) | Window.IsVisible(1113) | Window.IsVisible(1114) | Window.IsVisible(1115) | Window.IsVisible(1116) | Window.IsActive(1118)</expression>
 
-    <expression name="IsRecognizedVideoContent">VideoPlayer.Content(movies) | VideoPlayer.Content(episodes) | VideoPlayer.Content(livetv) | VideoPlayer.Content(musicvideos) | Pvr.IsPlayingRecording</expression>
+    <expression name="IsRecognizedVideoContent">VideoPlayer.Content(movies) | VideoPlayer.Content(episodes) | VideoPlayer.Content(livetv) | VideoPlayer.Content(musicvideos) | VideoPlayer.Content(files) | Pvr.IsPlayingRecording</expression>
 
     <expression name="IsPlayingUnrecognizedContent">Player.HasVideo + Player.Playing + ![VideoPlayer.Content(movies) | VideoPlayer.Content(episodes) | VideoPlayer.Content(musicvideos) | VideoPlayer.Content(livetv) | VideoPlayer.Content(files) | Pvr.IsPlayingRecording]</expression>
 
-    <expression name="IsPlayingRecognizedContent">Player.Paused + Player.HasVideo | Player.HasVideo + Player.Playing + [VideoPlayer.Content(movies) | VideoPlayer.Content(episodes) | VideoPlayer.Content(livetv) | VideoPlayer.Content(musicvideos) | Pvr.IsPlayingRecording]</expression>
+    <expression name="IsPlayingRecognizedContent">Player.Paused + Player.HasVideo | Player.HasVideo + Player.Playing + [VideoPlayer.Content(movies) | VideoPlayer.Content(episodes) | VideoPlayer.Content(livetv) | VideoPlayer.Content(musicvideos) | VideoPlayer.Content(files) | Pvr.IsPlayingRecording]</expression>
 
     <expression name="IsMainMenuOpened">ControlGroup(9001).HasFocus() | Control.HasFocus(900) | String.IsEqual(Window(Home).Property(ShowViewSubMenu),show)</expression>
 

--- a/xml/Includes.xml
+++ b/xml/Includes.xml
@@ -100,7 +100,7 @@
 
     <expression name="IsRecognizedVideoContent">VideoPlayer.Content(movies) | VideoPlayer.Content(episodes) | VideoPlayer.Content(livetv) | VideoPlayer.Content(musicvideos) | Pvr.IsPlayingRecording</expression>
 
-    <expression name="IsPlayingUnrecognizedContent">Player.HasVideo + Player.Playing + ![VideoPlayer.Content(movies) | VideoPlayer.Content(episodes) | VideoPlayer.Content(musicvideos) | VideoPlayer.Content(livetv) | Pvr.IsPlayingRecording]</expression>
+    <expression name="IsPlayingUnrecognizedContent">Player.HasVideo + Player.Playing + ![VideoPlayer.Content(movies) | VideoPlayer.Content(episodes) | VideoPlayer.Content(musicvideos) | VideoPlayer.Content(livetv) | VideoPlayer.Content(files) | Pvr.IsPlayingRecording]</expression>
 
     <expression name="IsPlayingRecognizedContent">Player.Paused + Player.HasVideo | Player.HasVideo + Player.Playing + [VideoPlayer.Content(movies) | VideoPlayer.Content(episodes) | VideoPlayer.Content(livetv) | VideoPlayer.Content(musicvideos) | Pvr.IsPlayingRecording]</expression>
 

--- a/xml/IncludesBackgroundBuilding.xml
+++ b/xml/IncludesBackgroundBuilding.xml
@@ -68,6 +68,7 @@
 <!-- Side Menu Background Panel Color -->
     <include name="Dim_Overlay">
         <control type="group">
+            <visible>!Skin.HasSetting(BackgroundNowPlaying)</visible>
             <control type="image">
                 <include>FullscreenDimensions</include>
                 <visible>$PARAM[visibility]</visible>
@@ -172,6 +173,11 @@
         <control type="group">
             <include condition="String.IsEqual(Skin.String(season_greetings),halloween_animation)">pumpkin</include>
         </control>		
+
+		<control type="videowindow">
+            <visible>Skin.HasSetting(BackgroundNowPlaying)</visible>
+			<include>FullscreenDimensions</include>
+		</control>
 
     </include>
 	

--- a/xml/IncludesSkinSettings.xml
+++ b/xml/IncludesSkinSettings.xml
@@ -1078,7 +1078,7 @@
             <selected>Skin.HasSetting(RandomizeBackground)</selected>
         </control>
         <!--background now playing-->
-        <control type="radiobutton" id="13018">
+        <control type="radiobutton" id="320238">
             <include>SkinSettings_Button</include>
             <label>320238</label>
             <onclick>Skin.ToggleSetting(BackgroundNowPlaying)</onclick>

--- a/xml/IncludesSkinSettings.xml
+++ b/xml/IncludesSkinSettings.xml
@@ -1077,6 +1077,13 @@
             <onclick>Skin.ToggleSetting(RandomizeBackground)</onclick>
             <selected>Skin.HasSetting(RandomizeBackground)</selected>
         </control>
+        <!--background now playing-->
+        <control type="radiobutton" id="13018">
+            <include>SkinSettings_Button</include>
+            <label>320238</label>
+            <onclick>Skin.ToggleSetting(BackgroundNowPlaying)</onclick>
+            <selected>Skin.HasSetting(BackgroundNowPlaying)</selected>
+        </control>
     </include>
 
     <!-- Media Library Views Settings -->

--- a/xml/IncludesViews.xml
+++ b/xml/IncludesViews.xml
@@ -1711,25 +1711,18 @@
         
         <!--Watched Overlay-->
         <include>PVRWatchedIndicator</include>
-        
-        <control type="label" id="1">
-            <!--Channel Now Playing (with recording or timer active)-->
-            <visible>[ListItem.IsRecording | ListItem.HasTimer | ListItem.IsPlaying]</visible>
-            <posx>0</posx>
-            <posy>0</posy>
-            <width>0</width>
-            <height>92%</height>
-            <include condition="!String.IsEqual(Skin.String(GuideRows),7)">Font_Reg24</include>
-            <include condition="Skin.String(GuideRows, 7)">Font_Reg31</include>
-            <aligny>center</aligny>
-            <textoffsetx>55</textoffsetx>
-            <textcolor>$INFO[Skin.String(PVRGuideItemTextColorUnfocus)]</textcolor>
-            <label>$INFO[ListItem.Label]</label>
-        </control>
+
+		<control type="image">
+			<left>4</left>
+			<top>45</top>
+			<width>16</width>
+			<height>16</height>
+			<texture>pvr/icons/pvr_record.png</texture>
+			<visible>[ListItem.IsRecording | ListItem.HasRecording | ListItem.IsPlayable]</visible>
+		</control>
         
         <control type="label" id="1">
             <!--Channel Now Playing-->
-            <visible>![ListItem.IsRecording | ListItem.HasTimer | ListItem.IsPlaying]</visible>
             <posx>0</posx>
             <posy>0</posy>
             <width>0</width>
@@ -1755,26 +1748,18 @@
         </control>
         
         <include>PVRWatchedIndicator</include>
-        
-        <control type="label" id="1">
-            <!--Channel Now Playing (with recording or timer active)-->
-            <visible>[ListItem.IsRecording | ListItem.HasTimer | ListItem.IsPlaying]</visible>
-            <posx>0</posx>
-            <posy>0</posy>
-            <width>0</width>
-            <height>92%</height>
-            <include condition="!String.IsEqual(Skin.String(GuideRows),7)">Font_Reg24</include>
-            <include condition="Skin.String(GuideRows, 7)">Font_Reg31</include>
-            <aligny>center</aligny>
-            <textoffsetx>55</textoffsetx>
-            <textcolor>$INFO[Skin.String(PVRGuideItemTextColorFocus)]</textcolor>
-            <label>$INFO[ListItem.Label]</label>
-            <scroll>true</scroll>
-        </control>
+
+		<control type="image">
+			<left>4</left>
+			<top>45</top>
+			<width>16</width>
+			<height>16</height>
+			<texture>pvr/icons/pvr_record.png</texture>
+			<visible>[ListItem.IsRecording | ListItem.HasRecording | ListItem.IsPlayable]</visible>
+		</control>
         
         <control type="label" id="1">
             <!--Channel Now Playing-->
-            <visible>![ListItem.IsRecording | ListItem.HasTimer | ListItem.IsPlaying]</visible>
             <posx>0</posx>
             <posy>0</posy>
             <width>0</width>

--- a/xml/IncludesViews.xml
+++ b/xml/IncludesViews.xml
@@ -1714,7 +1714,7 @@
 
 		<control type="image">
 			<left>4</left>
-			<top>45</top>
+			<bottom>8</bottom>
 			<width>16</width>
 			<height>16</height>
 			<texture>pvr/icons/pvr_record.png</texture>
@@ -1751,7 +1751,7 @@
 
 		<control type="image">
 			<left>4</left>
-			<top>45</top>
+			<bottom>8</bottom>
 			<width>16</width>
 			<height>16</height>
 			<texture>pvr/icons/pvr_record.png</texture>


### PR DESCRIPTION
Screenshots:

1. catchup indicator 7 rows (red circles)
![image](https://github.com/AchillesPunks/skin.titan.bingie.mod/assets/3100059/3b490d55-9028-4002-be35-dfdd6856ff21)

2. catchup indicator 10 rows (red circles)
![image](https://github.com/AchillesPunks/skin.titan.bingie.mod/assets/3100059/6316ff25-4bac-4e9c-b124-6e131d727cfc)

3. play programme button in PVR Info dialog
![image](https://github.com/AchillesPunks/skin.titan.bingie.mod/assets/3100059/b26195f7-a95a-4fef-b779-81a150c24781)

4. now playing as background
![image](https://github.com/AchillesPunks/skin.titan.bingie.mod/assets/3100059/7d70d7cd-f4b5-4e14-9e9c-b4c8412ed657)


